### PR TITLE
v0.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HKQM"
 uuid = "95871d0a-b0d4-4f82-9ec8-411977f2e218"
 authors = ["Teemu Järvinen <teemu.jarvinen@helsinki.fi> and contributors"]
-version = "0.2.2-DEV"
+version = "0.2.2"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"


### PR DESCRIPTION
Tag v0.2.2 that will be the last version with <v1.9 Julia support.

Newer versions should start using Package extensions