### PR TITLE
Update TensorOperations to v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,9 +28,11 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 [weakdeps]
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
+cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
 [extensions]
 TensorOperations_HKQM_ext = "TensorOperations"
+TensorOperations_cuTENSOR_HKQM_ext = ["TensorOperations", "cuTENSOR"]
 Tullio_HKQM_ext = "Tullio"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -26,12 +26,10 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [weakdeps]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 
 [extensions]
-TensorOperations_CUDA_HKQM_ext = ["TensorOperations", "CUDA"]
 TensorOperations_HKQM_ext = "TensorOperations"
 Tullio_HKQM_ext = "Tullio"
 
@@ -52,7 +50,7 @@ QuadGK = "2.4"
 Reexport = "0.2, 1.0"
 SpecialFunctions = "0.10, 1.0, 2"
 StaticArrays = "0.12, 1.0"
-TensorOperations = "3.0"
+TensorOperations = "4"
 Tullio = "0.3"
 Unitful = "1.5"
 UnitfulAtomic = "1.0"

--- a/docs/src/different-variables.md
+++ b/docs/src/different-variables.md
@@ -129,15 +129,15 @@ bracket(qs, p, qs)
 ### Alternative TensorOperations backend for CUDA
 
 For CUDA there is alternative TensorOperations backend
-that also support forward mode AD and is most likely faster
-than the default backend.
+that from TensorOperations extension.
 
 To use TensorOperations CUDA backend start by
 
 ```julia
 using CUDA
+using cuCUDA
 using TensorOperations
 using HKQM
 ```
 
-and use either `Array` or `CuArray` types.
+and using `CuArray` type should now use TensorOperations cuTENSOR backend.

--- a/ext/TensorOperations_CUDA_HKQM_ext.jl
+++ b/ext/TensorOperations_CUDA_HKQM_ext.jl
@@ -1,5 +1,7 @@
 module TensorOperations_CUDA_HKQM_ext
-    
+# This is retired for now
+# as TensorOperations v4 does not need this
+ 
 using CUDA
 using TensorOperations
 using HKQM


### PR DESCRIPTION
This allows using newer CUDA due to getting newer TensorOperations backend.

CUDA is broken with TensorOperations for now. But that should be an issue upstream, so making this PR